### PR TITLE
refactor(Queue): change queues to only handle items, not connections

### DIFF
--- a/src/ConnectionQueue.js
+++ b/src/ConnectionQueue.js
@@ -42,29 +42,15 @@ export default class ConnectionQueue {
    * @return {AbstractConnection} - first connection
    */
   first() {
-    if (this.connections.first() === undefined) {
-      return undefined;
-    }
-
-    return this.connections.first().connection;
-  }
-
-  /**
-   * returns a new queue without the first connection
-   * @return {ConnectionQueue} – ConnectionQueue without first connection
-   */
-  shift() {
-    return new ConnectionQueue(this.connections.shift());
+    return this.connections.first();
   }
 
   /**
    * Adds given connection to queue
-   * @param {AbstractConnection} connection – Connection to be added to queue
-   * @param {Integer} [priority] – priority of connection
+   * @param {ConnectionQueueItem} item – ConnectionQueueItem wich contains connection to be added to queue
    * @return {ConnectionQueue} - ConnectionQueue containing the added connection
    */
-  enqueue(connection, priority) {
-    const item = new ConnectionQueueItem(connection, priority);
+  enqueue(item) {
     const index = this.connections.findIndex(listItem => listItem.equals(item));
     let connections = null;
 
@@ -94,17 +80,13 @@ export default class ConnectionQueue {
    * @param {AbstractConnection} connection – connection to be deleted
    * @return {ConnectionQueue} - ConnectionQueue without the resp. connection
    */
-  dequeue(connection) {
-    const item = new ConnectionQueueItem(connection);
-
+  dequeue(item) {
     return new ConnectionQueue(
       this.connections.filter(listItem => !listItem.equals(item))
     );
   }
 
-  includes(connection) {
-    const item = new ConnectionQueueItem(connection);
-
+  includes(item) {
     return this.connections.some(listItem => listItem.equals(item));
   }
 }

--- a/src/__tests__/ConnectionQueue-test.js
+++ b/src/__tests__/ConnectionQueue-test.js
@@ -8,11 +8,17 @@ describe("ConnectionQueue", () => {
   let connection1 = null;
   let connection2 = null;
   let connection3 = null;
+  let item1 = null;
+  let item2 = null;
+  let item3 = null;
 
   beforeEach(() => {
     connection1 = new AbstractConnection("http://example.com/1");
     connection2 = new AbstractConnection("http://example.com/2");
     connection3 = new AbstractConnection("http://example.com/3");
+    item1 = new ConnectionQueueItem(connection1);
+    item2 = new ConnectionQueueItem(connection2, 2);
+    item3 = new ConnectionQueueItem(connection3, 3);
   });
 
   describe("#init", () => {
@@ -35,25 +41,23 @@ describe("ConnectionQueue", () => {
 
   describe("#enqueue", () => {
     it("enqueues correctly (first)", () => {
-      const connection = new AbstractConnection("http://example.com");
-      const queue = new ConnectionQueue().enqueue(connection);
+      const queue = new ConnectionQueue().enqueue(item1);
 
-      expect(queue.first()).toEqual(connection);
+      expect(queue.first()).toEqual(item1);
     });
 
     it("enqueues correctly (size)", () => {
-      const connection = new AbstractConnection("http://example.com");
-      const queue = new ConnectionQueue().enqueue(connection);
+      const queue = new ConnectionQueue().enqueue(item1);
 
       expect(queue.size).toEqual(1);
     });
 
     it("sorts connections by priority", () => {
       const queue = new ConnectionQueue()
-        .enqueue(connection1, 1)
-        .enqueue(connection2, 2);
+        .enqueue(item2)
+        .enqueue(item3);
 
-      expect(queue.first()).toEqual(connection2);
+      expect(queue.first()).toEqual(item2);
     });
   });
 
@@ -61,23 +65,23 @@ describe("ConnectionQueue", () => {
     describe("with existing connection", function() {
       it("dequeues correctly (first)", () => {
         const queue = new ConnectionQueue()
-          .enqueue(connection1)
-          .dequeue(connection1);
+          .enqueue(item1)
+          .dequeue(item1);
 
         expect(queue.first()).toBe(undefined);
       });
 
       it("dequeues correctly (size)", () => {
         const queue = new ConnectionQueue()
-          .enqueue(connection1)
-          .dequeue(connection1);
+          .enqueue(item1)
+          .dequeue(item1);
 
         expect(queue.size).toEqual(0);
       });
     });
     describe("with connection that doesn't exist", function() {
       it("doesn't do anything", () => {
-        expect(() => new ConnectionQueue().dequeue(connection1)).not.toThrow();
+        expect(() => new ConnectionQueue().dequeue(item1)).not.toThrow();
       });
     });
   });
@@ -85,11 +89,12 @@ describe("ConnectionQueue", () => {
   describe("#first", function() {
     it("returns first item of queue", function() {
       const queue = new ConnectionQueue()
-        .enqueue(connection1, 1)
-        .enqueue(connection2, 2)
-        .enqueue(connection3, 3);
+        .enqueue(item1)
+        .enqueue(item2)
+        .enqueue(item3);
+      const first = queue.first()
 
-      expect(queue.first()).toBe(connection3);
+      expect(first.equals(item3)).toBe(true);
     });
     it("returns undefined when calling first on empty queue", function() {
       const queue = new ConnectionQueue();
@@ -100,35 +105,30 @@ describe("ConnectionQueue", () => {
 
   describe("#shift", function() {
     it("returns a new queue without the first element", function() {
-      const queue = new ConnectionQueue()
-        .enqueue(connection1, 1)
-        .enqueue(connection2, 2)
-        .enqueue(connection3, 3)
-        .shift();
+      let queue = new ConnectionQueue()
+        .enqueue(item1)
+        .enqueue(item2)
+        .enqueue(item3);
+      queue = queue.dequeue(queue.first());
 
-      expect(queue.includes(connection3)).toEqual(false);
-    });
-    it("returns empty queue when shift() on empty queue", function() {
-      const queue = new ConnectionQueue().shift();
-
-      expect(queue.size).toEqual(0);
+      expect(queue.includes(item3)).toEqual(false);
     });
   });
 
   describe("#includes", () => {
     describe("with existing connection", function() {
       it("dequeues correctly (size)", () => {
-        const queue = new ConnectionQueue().enqueue(connection1);
+        const queue = new ConnectionQueue().enqueue(item1);
 
         expect(
-          queue.connections.includes(new ConnectionQueueItem(connection1))
+          queue.connections.includes(item1)
         ).toEqual(true);
       });
     });
 
     describe("with connection that doesn't exist", function() {
       it("doesn't do anything", () => {
-        expect(new ConnectionQueue().includes(connection1)).toEqual(false);
+        expect(new ConnectionQueue().includes(item1)).toEqual(false);
       });
     });
   });


### PR DESCRIPTION
This PR refactors the `ConnectionQueue` to only deal with `ConnectionQueueItems`, not bothering with `connections` directly.

The change is needed to an upcoming change where the CM will be able to cancel(kill) open connections in favour of more important ones. This change will enable us to instantly (force) start special connection types.

This change should only change internal details and should not break any external interface of the CM.

Also I have removed the `shift()`-method from the Queue, `dequeue` does more or less the same… 