### PR TITLE
Step #1: refactor(ConnectionQueue): make queue only deal with queueItems

### DIFF
--- a/src/ConnectionQueue.js
+++ b/src/ConnectionQueue.js
@@ -42,29 +42,39 @@ export default class ConnectionQueue {
    * @return {AbstractConnection} - first connection
    */
   first() {
-    if (this.connections.first() === undefined) {
-      return undefined;
-    }
-
-    return this.connections.first().connection;
+    return this.connections.first();
   }
 
   /**
-   * returns a new queue without the first connection
-   * @return {ConnectionQueue} – ConnectionQueue without first connection
+   * returns the last connection
+   * @return {AbstractConnection} - last connection
+   */
+  last() {
+    return this.connections.last();
+  }
+
+  /**
+   * returns a new queue without the first element
+   * @return {ConnectionQueue} - new queue without first element
    */
   shift() {
     return new ConnectionQueue(this.connections.shift());
   }
 
   /**
+   * returns a new queue without the last element
+   * @return {ConnectionQueue} - new queue without last element
+   */
+  pop() {
+    return new ConnectionQueue(this.connections.pop());
+  }
+
+  /**
    * Adds given connection to queue
-   * @param {AbstractConnection} connection – Connection to be added to queue
-   * @param {Integer} [priority] – priority of connection
+   * @param {ConnectionQueueItem} item – ConnectionQueueItem wich contains connection to be added to queue
    * @return {ConnectionQueue} - ConnectionQueue containing the added connection
    */
-  enqueue(connection, priority) {
-    const item = new ConnectionQueueItem(connection, priority);
+  enqueue(item) {
     const index = this.connections.findIndex(listItem => listItem.equals(item));
     let connections = null;
 
@@ -94,17 +104,13 @@ export default class ConnectionQueue {
    * @param {AbstractConnection} connection – connection to be deleted
    * @return {ConnectionQueue} - ConnectionQueue without the resp. connection
    */
-  dequeue(connection) {
-    const item = new ConnectionQueueItem(connection);
-
+  dequeue(item) {
     return new ConnectionQueue(
       this.connections.filter(listItem => !listItem.equals(item))
     );
   }
 
-  includes(connection) {
-    const item = new ConnectionQueueItem(connection);
-
+  includes(item) {
     return this.connections.some(listItem => listItem.equals(item));
   }
 }

--- a/src/ConnectionQueue.js
+++ b/src/ConnectionQueue.js
@@ -84,17 +84,7 @@ export default class ConnectionQueue {
       connections = this.connections.push(item);
     }
 
-    connections = connections.sort(({ priority: a }, { priority: b }) => {
-      if (a > b) {
-        return -1;
-      }
-
-      if (a < b) {
-        return 1;
-      }
-
-      return 0;
-    });
+    connections = connections.sortBy(item => (-1) * item.priority);
 
     return new ConnectionQueue(connections);
   }

--- a/src/__tests__/ConnectionQueue-test.js
+++ b/src/__tests__/ConnectionQueue-test.js
@@ -8,11 +8,17 @@ describe("ConnectionQueue", () => {
   let connection1 = null;
   let connection2 = null;
   let connection3 = null;
+  let item1 = null;
+  let item2 = null;
+  let item3 = null;
 
   beforeEach(() => {
     connection1 = new AbstractConnection("http://example.com/1");
     connection2 = new AbstractConnection("http://example.com/2");
     connection3 = new AbstractConnection("http://example.com/3");
+    item1 = new ConnectionQueueItem(connection1, 1);
+    item2 = new ConnectionQueueItem(connection2, 2);
+    item3 = new ConnectionQueueItem(connection3, 3);
   });
 
   describe("#init", () => {
@@ -35,49 +41,41 @@ describe("ConnectionQueue", () => {
 
   describe("#enqueue", () => {
     it("enqueues correctly (first)", () => {
-      const connection = new AbstractConnection("http://example.com");
-      const queue = new ConnectionQueue().enqueue(connection);
+      const queue = new ConnectionQueue().enqueue(item1);
 
-      expect(queue.first()).toEqual(connection);
+      expect(queue.first()).toEqual(item1);
     });
 
     it("enqueues correctly (size)", () => {
-      const connection = new AbstractConnection("http://example.com");
-      const queue = new ConnectionQueue().enqueue(connection);
+      const queue = new ConnectionQueue().enqueue(item1);
 
       expect(queue.size).toEqual(1);
     });
 
     it("sorts connections by priority", () => {
-      const queue = new ConnectionQueue()
-        .enqueue(connection1, 1)
-        .enqueue(connection2, 2);
+      const queue = new ConnectionQueue().enqueue(item2).enqueue(item3);
 
-      expect(queue.first()).toEqual(connection2);
+      expect(queue.first()).toEqual(item2);
     });
   });
 
   describe("#dequeue", () => {
     describe("with existing connection", function() {
       it("dequeues correctly (first)", () => {
-        const queue = new ConnectionQueue()
-          .enqueue(connection1)
-          .dequeue(connection1);
+        const queue = new ConnectionQueue().enqueue(item1).dequeue(item1);
 
         expect(queue.first()).toBe(undefined);
       });
 
       it("dequeues correctly (size)", () => {
-        const queue = new ConnectionQueue()
-          .enqueue(connection1)
-          .dequeue(connection1);
+        const queue = new ConnectionQueue().enqueue(item1).dequeue(item1);
 
         expect(queue.size).toEqual(0);
       });
     });
     describe("with connection that doesn't exist", function() {
       it("doesn't do anything", () => {
-        expect(() => new ConnectionQueue().dequeue(connection1)).not.toThrow();
+        expect(() => new ConnectionQueue().dequeue(item1)).not.toThrow();
       });
     });
   });
@@ -85,11 +83,12 @@ describe("ConnectionQueue", () => {
   describe("#first", function() {
     it("returns first item of queue", function() {
       const queue = new ConnectionQueue()
-        .enqueue(connection1, 1)
-        .enqueue(connection2, 2)
-        .enqueue(connection3, 3);
+        .enqueue(item1)
+        .enqueue(item2)
+        .enqueue(item3);
+      const first = queue.first();
 
-      expect(queue.first()).toBe(connection3);
+      expect(first.equals(item3)).toBe(true);
     });
     it("returns undefined when calling first on empty queue", function() {
       const queue = new ConnectionQueue();
@@ -98,37 +97,59 @@ describe("ConnectionQueue", () => {
     });
   });
 
+  describe("#last", function() {
+    it("returns last item of queue", function() {
+      const queue = new ConnectionQueue()
+        .enqueue(item1)
+        .enqueue(item2)
+        .enqueue(item3);
+      const last = queue.last();
+
+      expect(last.equals(item1)).toBe(true);
+    });
+    it("returns undefined when calling last on empty queue", function() {
+      const queue = new ConnectionQueue();
+
+      expect(queue.last()).toBe(undefined);
+    });
+  });
+
   describe("#shift", function() {
     it("returns a new queue without the first element", function() {
-      const queue = new ConnectionQueue()
-        .enqueue(connection1, 1)
-        .enqueue(connection2, 2)
-        .enqueue(connection3, 3)
-        .shift();
+      let queue = new ConnectionQueue()
+        .enqueue(item1)
+        .enqueue(item2)
+        .enqueue(item3);
+      queue = queue.shift();
 
-      expect(queue.includes(connection3)).toEqual(false);
+      expect(queue.includes(item3)).toEqual(false);
     });
-    it("returns empty queue when shift() on empty queue", function() {
-      const queue = new ConnectionQueue().shift();
+  });
 
-      expect(queue.size).toEqual(0);
+  describe("#pop", function() {
+    it("returns a new queue without the last element", function() {
+      let queue = new ConnectionQueue()
+        .enqueue(item1)
+        .enqueue(item2)
+        .enqueue(item3);
+      queue = queue.pop();
+
+      expect(queue.includes(item1)).toEqual(false);
     });
   });
 
   describe("#includes", () => {
     describe("with existing connection", function() {
       it("dequeues correctly (size)", () => {
-        const queue = new ConnectionQueue().enqueue(connection1);
+        const queue = new ConnectionQueue().enqueue(item1);
 
-        expect(
-          queue.connections.includes(new ConnectionQueueItem(connection1))
-        ).toEqual(true);
+        expect(queue.connections.includes(item1)).toEqual(true);
       });
     });
 
     describe("with connection that doesn't exist", function() {
       it("doesn't do anything", () => {
-        expect(new ConnectionQueue().includes(connection1)).toEqual(false);
+        expect(new ConnectionQueue().includes(item1)).toEqual(false);
       });
     });
   });


### PR DESCRIPTION
‼️ ONLY FOR TRACKING - DO NOT MERGE ‼️ 

---

This refactors the ConnectionQueue so that it is only dealing
with QueueItems and has not to bother with the connections itself

Only internal changes, nothing breaking (CM wise)