### PR TITLE
Step #3: feat(ConnectionManager): add force start and aborting of connections

### DIFF
--- a/src/ConnectionManager.js
+++ b/src/ConnectionManager.js
@@ -98,10 +98,30 @@ export default class ConnectionManager {
        */
       handleConnectionError: event =>
         this.dequeue(event.target),
+
+      /**
+       * Closes low prio connections until a slot is free
+       *
+       * @param {int} threshold
+       * @return {bool} - true if there is a free slot, false if not.
+       */
+      closeConnections(threshold) {
+        let item = this.openList.last();
+        while (
+          item &&
+          this.openList.size >= maxConnections - 1 &&
+          item.priority < threshold
+        ) {
+          this.instance.dequeue(item.connection);
+          item = this.openList.last();
+        }
+        return this.openList.size <= maxConnections - 1;
+      }
     };
 
     this.enqueue = this.enqueue.bind(context);
     this.dequeue = this.dequeue.bind(context);
+    this.force = this.force.bind(context);
   }
 
   /**
@@ -119,19 +139,29 @@ export default class ConnectionManager {
 
     const item = new ConnectionQueueItem(connection, priority);
 
+    // default case: connection is initialized, but not yet started
     if (connection.state === AbstractConnection.INIT) {
       this.waitingList = this.waitingList
         .push(item)
         .sortBy(listItem => -1 * listItem.priority);
     }
 
+    // theoreticly it is possible to open connections on your own
+    // and then add them to the manager, if this happens we have
+    // to deal with them correctly
     if (connection.state === AbstractConnection.OPEN) {
       if (this.openList.some(listItem => listItem.equals(item))) {
         return false;
       }
-      this.openList = this.openList
-        .push(item)
-        .sortBy(listItem => -1 * listItem.priority);
+      
+      if (this.closeConnections(item.priority)) {
+        this.openList = this.openList
+          .push(item)
+          .sortBy(listItem => -1 * listItem.priority);
+      } else {
+        connection.abort();
+        return false;
+      }
     }
 
     connection.addListener(ConnectionEvent.ABORT, this.handleConnectionAbort);
@@ -187,6 +217,28 @@ export default class ConnectionManager {
         listItem => !listItem.equals(item)
       );
       this.next();
+    }
+  }
+
+  /**
+   * Immediatly opens a given connection, cancels other connections if needed
+   *
+   * @this ConnectionManager~Context
+   * @param {AbstractConnection} connection
+   */
+  force(connection) {
+    const item = new ConnectionQueueItem(connection, Number.MAX_SAFE_INTEGER);
+
+    if (!this.closeConnections(item.priority)) {
+      return false;
+    }
+
+    if (item.connection.state === AbstractConnection.INIT) {
+      item.connection.open();
+    }
+
+    if (item.connection.state === AbstractConnection.OPEN) {
+      context.openList = context.openList.enqueue(item);
     }
   }
 }


### PR DESCRIPTION
‼️ ONLY FOR TRACKING - DO NOT MERGE ‼️ 

---

This enables the ConnectionManager to force start connections if
needed, also it cancels low prio connections when there are too
many open connections

Not really a breaking change, but it makes it necessary for
all clients to be aware of aborted connections.