### PR TITLE
Step #4: chore(ConnectionManager): merge force and enqueue method for easier use

### DIFF
--- a/src/ConnectionManager.js
+++ b/src/ConnectionManager.js
@@ -14,7 +14,7 @@ export default class ConnectionManager {
    *
    * @param {int} maxConnections – max open connections
    */
-  constructor(maxConnections = 6) {
+  constructor(maxConnections = 6, threshold = 0.7) {
     /**
      * Private Context
      *
@@ -58,7 +58,7 @@ export default class ConnectionManager {
         const item = context.waitingList.first();
 
         if (item.connection.state === AbstractConnection.INIT) {
-          item.connection.open();
+          context.openConnection(item.connection);
         }
 
         if (
@@ -98,6 +98,45 @@ export default class ConnectionManager {
        */
       handleConnectionError: event =>
         this.dequeue(event.target),
+
+      /**
+       * Closes low prio connections until a slot is free
+       *
+       * @param {int} priority
+       * @return {bool} - true if there is a free slot, false if not.
+       */
+      requestFreeSlot(priority) {
+        let item = this.openList.last();
+        while (
+          item &&
+          this.openList.size >= maxConnections - 1 &&
+          item.priority < priority * threshold
+        ) {
+          this.instance.dequeue(item.connection);
+          item = this.openList.last();
+        }
+        return this.openList.size <= maxConnections - 1;
+      },
+
+      /**
+       * Opens a Connection
+       * 
+       * @param {AbstractConnection} connection
+       */
+      openConnection(connection) {
+        connection.open();
+      },
+
+      addListeners(connection) {
+        connection.addListener(ConnectionEvent.ABORT, this.handleConnectionAbort);
+
+        connection.addListener(
+          ConnectionEvent.COMPLETE,
+          this.handleConnectionComplete
+        );
+
+        connection.addListener(ConnectionEvent.ERROR, this.handleConnectionError);
+      }
     };
 
     this.enqueue = this.enqueue.bind(context);
@@ -113,39 +152,56 @@ export default class ConnectionManager {
    * @return {bool} - true if the connection was added, false if not.
    */
   enqueue(connection, priority) {
+    // maybe we got a closed connection, nothing to do.
     if (connection.state === AbstractConnection.CLOSED) {
       return false;
     }
 
     const item = new ConnectionQueueItem(connection, priority);
 
+    // theoreticly it is possible to open connections on your own
+    // and then add them to the manager, if this happens we have
+    // to deal with them correctly
+    if (item.connection.state === AbstractConnection.OPEN) {
+      if (this.requestFreeSlot(item.priority)) {
+        this.addListeners(item.connection);
+        this.openList = this.openList
+          .push(item)
+          .sortBy(listItem => -1 * listItem.priority);
+        return true;
+      } else {
+        // 
+        item.connection.abort();
+        return false;
+      }
+    }
+
+    // from here on, we have a connection with state == INIT
+
+    // add listeners for handling it - these will call this.next() when the connection is closed.
+    this.addListeners(item.connection);
+
+    // lets see if we can kill other low priority connections 
+    // in favor of this one.
+    if (this.requestFreeSlot(item.priority)) {
+      this.openConnection(item.connection);
+    }
+    
+    // ^ no free slot, connection is still initialized, enqueue it in waiting list
     if (connection.state === AbstractConnection.INIT) {
       this.waitingList = this.waitingList
         .push(item)
         .sortBy(listItem => -1 * listItem.priority);
     }
 
-    if (connection.state === AbstractConnection.OPEN) {
-      if (this.openList.some(listItem => listItem.equals(item))) {
-        return false;
-      }
+    // ^^ there was a free slot => connection is open, put in openList
+    if(connection.state === AbstractConnection.OPEN) {
       this.openList = this.openList
-        .push(item)
-        .sortBy(listItem => -1 * listItem.priority);
+          .push(item)
+          .sortBy(listItem => -1 * listItem.priority);
     }
-
-    connection.addListener(ConnectionEvent.ABORT, this.handleConnectionAbort);
-
-    connection.addListener(
-      ConnectionEvent.COMPLETE,
-      this.handleConnectionComplete
-    );
-
-    connection.addListener(ConnectionEvent.ERROR, this.handleConnectionError);
-
-    // important: when it returns true here, the connection
-    // might already been started in the next()-loop.
-    this.next();
+    
+    // connection was enqueued (or directly started).
     return true;
   }
 


### PR DESCRIPTION
In this PR I have merged the `force` & `enqueue` methods for easier use. this also makes the whole `enqueue` methods and `next` calls less complicated.